### PR TITLE
fix: correct parameter name for VectorStoreFactory.create_vectorstore()

### DIFF
--- a/backend/services/preprocessing_pipeline.py
+++ b/backend/services/preprocessing_pipeline.py
@@ -399,7 +399,7 @@ class PreprocessingPipelineService:
         # Get vectorstore from factory
         return VectorStoreFactory.create_vectorstore(
             backend=processed_ds.vector_backend,
-            embeddings=embeddings,
+            embedding_function=embeddings,
             collection_name=processed_ds.collection_name,
         )
 


### PR DESCRIPTION
The preprocessing pipeline was calling create_vectorstore() with `embeddings=embeddings`, but the factory method expects the parameter to be named `embedding_function`. This caused a TypeError that made ALL dataset processing fail silently (datasets stuck in 'processing' state).

Fixed by changing the parameter name from `embeddings` to `embedding_function`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)